### PR TITLE
CI: name job

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -6,13 +6,14 @@ on:
     - cron: "11 21 * * *"
 jobs:
   RSpec:
+    name: "Ruby ${{ matrix.ruby }}"
     runs-on: ubuntu-latest
     strategy:
       matrix:
         ruby:
           - 2.5
           - 2.7
-          - 3.0
+          - "3.0"
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
Call it "3.0" to avoid YAML Float-to-String precision loss (3.0 => "3").

---

This is a very small change, but which avoids a Float-to-String loss of characters.

An example (not from this project) of what it can look like before this change, in this picture:

<img width="376" alt="bild" src="https://user-images.githubusercontent.com/211/119782378-6ad6cd00-becc-11eb-9e13-9a425adaa054.png">

Read more details, if you like: https://github.com/actions/runner/issues/849